### PR TITLE
fix:register check modal

### DIFF
--- a/src/components/SiteRegisterDialog.tsx
+++ b/src/components/SiteRegisterDialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import useSiteRegisterDialog from './useSiteRegisterDialog.ts'
-
+import { mutate } from 'swr'
+import { BASE_URL } from '../common/api.js'
 
 const SiteRegisterDialog = ({ id }: { id?: number }) => {
   const {
@@ -103,14 +104,6 @@ const SiteRegisterDialog = ({ id }: { id?: number }) => {
             </button>
           </div>
           <div className="flex pt-4 gap-3 justify-end">
-            <button
-              className="btn"
-              onClick={() => {
-                setStep(1)
-              }}
-            >
-              뒤로
-            </button>
             <button onClick={() => onClickCheckButton()} className="btn btn-primary" type="button">
               확인
             </button>
@@ -132,6 +125,7 @@ const SiteRegisterDialog = ({ id }: { id?: number }) => {
             className="btn"
             onClick={() => {
               onCloseModal()
+              mutate(`${BASE_URL}/sites`)
             }}
           >
             완료
@@ -153,6 +147,7 @@ const SiteRegisterDialog = ({ id }: { id?: number }) => {
               className="btn"
               onClick={() => {
                 onCloseModal()
+                mutate(`${BASE_URL}/sites`)
               }}
             >
               닫기

--- a/src/components/SiteRegisterDialog.tsx
+++ b/src/components/SiteRegisterDialog.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import useSiteRegisterDialog from './useSiteRegisterDialog.ts'
 import { mutate } from 'swr'
 import { BASE_URL } from '../common/api.js'
 
-const SiteRegisterDialog = ({ id }: { id?: number }) => {
+const SiteRegisterDialog = ({ id, registerCheckNumber }: { id?: number; registerCheckNumber: number }) => {
   const {
     metaTag,
     name,
@@ -19,7 +19,9 @@ const SiteRegisterDialog = ({ id }: { id?: number }) => {
     setStep,
     onCloseModal,
     isDisabledNextBtn,
-  } = useSiteRegisterDialog({ id: id ? id : undefined })
+  } = useSiteRegisterDialog({ id: id ? id : undefined, registerCheckNumber })
+
+
 
   if (!metaTag || step === 1)
     return (

--- a/src/components/useSiteRegisterDialog.ts
+++ b/src/components/useSiteRegisterDialog.ts
@@ -5,89 +5,88 @@ import { isValidURL } from '../utils/validation.ts'
 import siteMetaTag from '../useCases/siteMetaTag.ts'
  import { toast } from 'react-toastify'
 
- const useSiteRegisterDialog = ({ id }: { id?: number }) => {
-   const [name, setName] = useState<string>('')
-   const [url, setUrl] = useState<string>('')
-   const [description, setDescription] = useState<string>('')
-   const [resId, setResId] = useState<number>(0)
-   const [metaTag, setMetaTag] = useState<string>('')
-   const [step, setStep] = useState<number>(1)
-   const [isDisabledNextBtn, setIsDisabledNextBtn] = useState<boolean>(true)
+const useSiteRegisterDialog = ({ id }: { id?: number }) => {
+  const [name, setName] = useState<string>('')
+  const [url, setUrl] = useState<string>('')
+  const [description, setDescription] = useState<string>('')
+  const [siteId, setSiteId] = useState<number>(0)
+  const [metaTag, setMetaTag] = useState<string>('')
+  const [step, setStep] = useState<number>(1)
+  const [isDisabledNextBtn, setIsDisabledNextBtn] = useState<boolean>(true)
 
-   const onClickNextButton = async () => {
-     try {
-       const res = await postSite({ name, url, description })
-       setMetaTag(res.metaTag)
-       setResId(res.id)
-       setStep(2)
-     } catch {
-       toast('사이트 등록에 실패했습니다. 다시 시도해주세요.')
-     }
-   }
+  const onClickNextButton = async () => {
+    try {
+      const res = await postSite({ name, url, description })
+      setMetaTag(res.metaTag)
+      setSiteId(res.id)
+      setStep(2)
+    } catch {
+      toast('사이트 등록에 실패했습니다. 다시 시도해주세요.')
+    }
+  }
 
-   const onClickCheckButton = async () => {
-     try {
-       await siteCheck({ id: resId })
-       setStep(3)
-     } catch {
-       setStep(4)
-     }
-   }
+  const onClickCheckButton = async () => {
+    try {
+      await siteCheck({ id: siteId })
+      setStep(3)
+    } catch {
+      setStep(4)
+    }
+  }
 
-   const copyMetaTag = () => {
-     navigator.clipboard.writeText(`<meta name="quack-run-service-verification" content="${metaTag}">`)
-   }
+  const copyMetaTag = () => {
+    navigator.clipboard.writeText(`<meta name="quack-run-service-verification" content="${metaTag}">`)
+  }
 
-   const onCloseModal = () => {
-     setDescription('')
-     setMetaTag('')
-     setName('')
-     setUrl('')
-     setStep(1)
-     ;(document.getElementById('site_register_dialog') as HTMLDialogElement)?.close()
-   }
+  const onCloseModal = () => {
+    setDescription('')
+    setMetaTag('')
+    setName('')
+    setUrl('')
+    setStep(1)
+    ;(document.getElementById('site_register_dialog') as HTMLDialogElement)?.close()
+  }
 
-   useEffect(() => {
-     setIsDisabledNextBtn(name.length === 0 || !isValidURL(url))
-   }, [name, url])
+  useEffect(() => {
+    setIsDisabledNextBtn(name.length === 0 || !isValidURL(url))
+  }, [name, url])
 
-   useEffect(() => {
-     const fetchData = async () => {
-       if (id) {
-         try {
-           const res = await siteMetaTag({ id })
-           setMetaTag(res.content)
-           setStep(2)
-         } catch {
-           ;(document.getElementById('site_register_dialog') as HTMLDialogElement)?.close()
-           toast('사이트 메타 태그 정보 불러오기에 실패했습니다. 다시 시도해주세요.')
-           //TODO: 새 메타 태그 정보 발급받기 api 호출
-         }
-       }
-     }
+  useEffect(() => {
+    const fetchData = async () => {
+      if (id) {
+        try {
+          const res = await siteMetaTag({ id })
+          setMetaTag(res.content)
+          setStep(2)
+        } catch {
+          ;(document.getElementById('site_register_dialog') as HTMLDialogElement)?.close()
+          toast('사이트 메타 태그 정보 불러오기에 실패했습니다. 잠시 후 다시 시도해주세요.')
+        }
+      }
+    }
 
-     if (id) {
-       setResId(id)
-       fetchData()
-     }
-   }, [id])
+    if (id) {
+      setSiteId(id)
+      fetchData()
+    }
+  }, [id])
 
-   return {
-     name,
-     url,
-     description,
-     setName,
-     setUrl,
-     setDescription,
-     onClickNextButton,
-     metaTag,
-     onClickCheckButton,
-     copyMetaTag,
-     step,
-     setStep,
-     onCloseModal,
-     isDisabledNextBtn,
-   }
- }
+  return {
+    name,
+    url,
+    description,
+    setName,
+    setUrl,
+    setDescription,
+    onClickNextButton,
+    metaTag,
+    onClickCheckButton,
+    copyMetaTag,
+    step,
+    setStep,
+    onCloseModal,
+    isDisabledNextBtn,
+  }
+}
 
 export default useSiteRegisterDialog

--- a/src/components/useSiteRegisterDialog.ts
+++ b/src/components/useSiteRegisterDialog.ts
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import postSite from '../useCases/postSite.ts'
 import siteCheck from '../useCases/siteCheck.ts'
 import { isValidURL } from '../utils/validation.ts'
 import siteMetaTag from '../useCases/siteMetaTag.ts'
- import { toast } from 'react-toastify'
+import { toast } from 'react-toastify'
 
-const useSiteRegisterDialog = ({ id }: { id?: number }) => {
+const useSiteRegisterDialog = ({ id, registerCheckNumber }: { id?: number; registerCheckNumber: number }) => {
   const [name, setName] = useState<string>('')
   const [url, setUrl] = useState<string>('')
   const [description, setDescription] = useState<string>('')
@@ -13,6 +13,7 @@ const useSiteRegisterDialog = ({ id }: { id?: number }) => {
   const [metaTag, setMetaTag] = useState<string>('')
   const [step, setStep] = useState<number>(1)
   const [isDisabledNextBtn, setIsDisabledNextBtn] = useState<boolean>(true)
+  const [, updateState] = useState<Object>()
 
   const onClickNextButton = async () => {
     try {
@@ -69,7 +70,7 @@ const useSiteRegisterDialog = ({ id }: { id?: number }) => {
       setSiteId(id)
       fetchData()
     }
-  }, [id])
+  }, [id, registerCheckNumber])
 
   return {
     name,

--- a/src/pages/SiteList.tsx
+++ b/src/pages/SiteList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import SiteRegisterDialog from '../components/SiteRegisterDialog.tsx'
 import getUserList from '../useCases/siteList.ts'
@@ -6,6 +6,7 @@ import { OwnerProofStatus } from '../types/response/site.ts'
 
 const SiteList = () => {
   const { data, error, isLoading } = getUserList()
+  const [registerCheckNumber, setRegisterCheckNumber] = useState<number>(0)
   const [currentSiteId, setCurrentSiteId] = React.useState<number | undefined>(undefined)
   if (error) return <div>failed to load</div>
   if (isLoading) return <div>loading...</div>
@@ -39,6 +40,7 @@ const SiteList = () => {
                       className="btn btn-primary"
                       onClick={() => {
                         setCurrentSiteId(site.id)
+                        setRegisterCheckNumber(registerCheckNumber + 1)
                         ;(document.getElementById('site_register_dialog') as HTMLDialogElement)?.showModal()
                       }}
                     >
@@ -53,7 +55,7 @@ const SiteList = () => {
           </tbody>
         </table>
       </div>
-      <SiteRegisterDialog id={currentSiteId} />
+      <SiteRegisterDialog id={currentSiteId} registerCheckNumber={registerCheckNumber} />
     </>
   )
 }


### PR DESCRIPTION
1. 같은 사이트의 '소유권 확인' 버튼 두번 클릭 시 비정상적인 노출
2. 소유권 증명 모달에 뒤로 버튼 제거